### PR TITLE
Fix loop variable declarations in normalizeAddExtras

### DIFF
--- a/CvGame.cpp
+++ b/CvGame.cpp
@@ -1806,7 +1806,7 @@ void CvGame::normalizeAddExtras()
 												{
 												pLoopPlot->setFeatureType(NO_FEATURE);
 
-													for (iK = 0; iK < GC.getNumBonusInfos(); iK++)
+													for (int iK = 0; iK < GC.getNumBonusInfos(); iK++)
 													{
 														if (GC.getBonusInfo((BonusTypes)iK).isNormalize())
 														{
@@ -1838,7 +1838,7 @@ void CvGame::normalizeAddExtras()
 				
 				shuffleArray(aiShuffle, NUM_CITY_PLOTS, getMapRand());
 
-				for (iJ = 0; iJ < NUM_CITY_PLOTS; iJ++)
+				for (int iJ = 0; iJ < NUM_CITY_PLOTS; iJ++)
 				{
 					if (GET_PLAYER((PlayerTypes)iI).AI_foundValue(pStartingPlot->getX_INLINE(), pStartingPlot->getY_INLINE(), -1, true) >= iTargetValue)
 					{


### PR DESCRIPTION
## Summary
- declare the bonus and city plot loop indices in CvGame::normalizeAddExtras with explicit int types to avoid implicit declarations

## Testing
- not run (Visual Studio 2008 is unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e13c02e388833094639a439895f902