### PR TITLE
Fix conscript flyout menu unit id

### DIFF
--- a/CvGameInterface.cpp
+++ b/CvGameInterface.cpp
@@ -1993,7 +1993,7 @@ void CvGame::startFlyoutMenu(const CvPlot* pPlot, std::vector<CvFlyoutMenuData>&
 				if (eConscriptUnit != NO_UNIT)
 				{
 					szBuffer = gDLL->getText("TXT_KEY_DRAFT_UNIT", GC.getUnitInfo(eConscriptUnit).getDescription(), pCity->getConscriptPopulation());
-					aFlyoutItems.push_back(CvFlyoutMenuData(FLYOUT_CONSCRIPT, iI, pPlot->getX_INLINE(), pPlot->getY_INLINE(), szBuffer));
+					aFlyoutItems.push_back(CvFlyoutMenuData(FLYOUT_CONSCRIPT, static_cast<int>(eConscriptUnit), pPlot->getX_INLINE(), pPlot->getY_INLINE(), szBuffer));
 				}
 			}
 		}


### PR DESCRIPTION
## Summary
- use the conscript unit type when constructing the draft flyout menu entry instead of an undefined loop variable
- reviewed adjacent flyout menu entries to confirm they reference valid identifiers

## Testing
- not run (build not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e14b1157748330b81f9df893c69612