### PR TITLE
Fix AI corporation HQ lookup in spread logic

### DIFF
--- a/CvUnitAI.cpp
+++ b/CvUnitAI.cpp
@@ -8609,7 +8609,7 @@ bool CvUnitAI::AI_spreadCorporation()
 	{
 		return false;
 	}
-	bool bHasHQ = (GET_TEAM(getTeam()).hasHeadquarters((CorporationTypes)iI));
+	bool bHasHQ = GET_TEAM(getTeam()).hasHeadquarters(eCorporation);
 
 	int iBestValue = 0;
 	CvPlot* pBestPlot = NULL;


### PR DESCRIPTION
## Summary
- use the selected corporation when checking for an existing headquarters in AI_spreadCorporation

## Testing
- make -j4 *(fails: Makefile expects nmake syntax in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e29b3574748330977e6ba6a0bb152b